### PR TITLE
surface moon enemy health balance

### DIFF
--- a/Common/Global/NPCs/WeaponBalancing.cs
+++ b/Common/Global/NPCs/WeaponBalancing.cs
@@ -44,6 +44,10 @@ namespace Macrocosm.Common.Global.NPCs
 
             if (projectile.type == ProjectileID.EmpressBlade)
                 modifiers.FinalDamage *= 0.65f;
+
+            if (projectile.type == ProjectileID.MoonlordArrow || projectile.type == ProjectileID.MoonlordArrowTrail)
+                modifiers.FinalDamage *= 0.88f; // apparently luminite arrows are a beast on the moon, but are only used by one moon weapon and no ml weapons
+
         }
 
         public override void ModifyHitByItem(NPC npc, Player player, Item item, ref NPC.HitModifiers modifiers)

--- a/Content/Items/Weapons/Ranged/SeleniteBow.cs
+++ b/Content/Items/Weapons/Ranged/SeleniteBow.cs
@@ -18,7 +18,7 @@ namespace Macrocosm.Content.Items.Weapons.Ranged
         {
             Item.DefaultToBow(25, 20, true);
 
-            Item.damage = 115;
+            Item.damage = 110;
             Item.knockBack = 4;
 
             Item.width = 32;

--- a/Content/Items/Weapons/Ranged/SeleniteMagnum.cs
+++ b/Content/Items/Weapons/Ranged/SeleniteMagnum.cs
@@ -34,7 +34,7 @@ namespace Macrocosm.Content.Items.Weapons.Ranged
         public override void SetDefaultsHeldProjectile()
         {
             Item.DefaultToRangedWeapon(10, AmmoID.Bullet, 20, 20, true);
-            Item.damage = 280;
+            Item.damage = 205;
 
             Item.width = 42;
             Item.height = 24;
@@ -59,14 +59,14 @@ namespace Macrocosm.Content.Items.Weapons.Ranged
         {
             if (player.AltFunction())
             {
-                Item.damage = 240;
+                Item.damage = 135;
                 Item.useTime = 6;
                 Item.useAnimation = 36;
                 altUseCooldown = 65;
             }
             else
             {
-                Item.damage = 280;
+                Item.damage = 205;
                 Item.useTime = 20;
                 Item.useAnimation = 20;
             }

--- a/Content/NPCs/Enemies/Moon/Clavite.cs
+++ b/Content/NPCs/Enemies/Moon/Clavite.cs
@@ -44,9 +44,9 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 56;
             NPC.height = 56;
-            NPC.lifeMax = 700;
+            NPC.lifeMax = 1100;
             NPC.damage = 85;
-            NPC.defense = 60;
+            NPC.defense = 110;
             NPC.HitSound = SoundID.NPCHit2;
             NPC.DeathSound = SoundID.NPCDeath2;
             NPC.value = 60f;

--- a/Content/NPCs/Enemies/Moon/CraterCrawler.cs
+++ b/Content/NPCs/Enemies/Moon/CraterCrawler.cs
@@ -37,9 +37,9 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         public override void SetDefaults()
         {
             NPC.CloneDefaults(NPCID.DiggerHead);
-            NPC.lifeMax = 900;
+            NPC.lifeMax = 1800;
             NPC.damage = 90;
-            NPC.defense = 40;
+            NPC.defense = 120;
             NPC.width = 20;
             NPC.height = 20;
             SpawnModBiomes = [ModContent.GetInstance<MoonNightBiome>().Type];

--- a/Content/NPCs/Enemies/Moon/CrescentGhoul.cs
+++ b/Content/NPCs/Enemies/Moon/CrescentGhoul.cs
@@ -49,9 +49,9 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 72;
             NPC.height = 84;
-            NPC.lifeMax = 1000;
+            NPC.lifeMax = 1400;
             NPC.damage = 65;
-            NPC.defense = 70;
+            NPC.defense = 120;
             NPC.HitSound = SoundID.NPCHit2;
             NPC.DeathSound = SoundID.NPCDeath2;
             NPC.aiStyle = -1;

--- a/Content/NPCs/Enemies/Moon/MoonWorm.cs
+++ b/Content/NPCs/Enemies/Moon/MoonWorm.cs
@@ -88,8 +88,8 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.CloneDefaults(NPCID.DiggerHead);
             NPC.damage = 175;
-            NPC.lifeMax = 3250;
-            NPC.defense = 63;
+            NPC.lifeMax = 9000;
+            NPC.defense = 180;
             FlipSprite = true;
             NPC.width = 86;
             NPC.height = 86;

--- a/Content/NPCs/Enemies/Moon/MoonZombie.cs
+++ b/Content/NPCs/Enemies/Moon/MoonZombie.cs
@@ -22,8 +22,8 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
             NPC.width = 18;
             NPC.height = 44;
             NPC.damage = 80;
-            NPC.defense = 65;
-            NPC.lifeMax = 600;
+            NPC.defense = 90;
+            NPC.lifeMax = 1000;
             NPC.HitSound = SoundID.NPCHit1;
             NPC.DeathSound = SoundID.NPCDeath2;
             NPC.knockBackResist = 0.5f;

--- a/Content/NPCs/Enemies/Moon/RegolithSlime.cs
+++ b/Content/NPCs/Enemies/Moon/RegolithSlime.cs
@@ -23,8 +23,8 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
             NPC.width = 36;
             NPC.height = 22;
             NPC.damage = 60;
-            NPC.defense = 50;
-            NPC.lifeMax = 450;
+            NPC.defense = 60;
+            NPC.lifeMax = 900;
             NPC.HitSound = SoundID.NPCHit1;
             NPC.DeathSound = SoundID.NPCDeath1;
             NPC.value = 60f;

--- a/Content/NPCs/Enemies/Moon/ZombieSecurity.cs
+++ b/Content/NPCs/Enemies/Moon/ZombieSecurity.cs
@@ -67,8 +67,8 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
             NPC.width = 24;
             NPC.height = 44;
             NPC.damage = 75;
-            NPC.defense = 75;
-            NPC.lifeMax = 650;
+            NPC.defense = 100;
+            NPC.lifeMax = 1300;
             NPC.HitSound = SoundID.NPCHit1;
             NPC.DeathSound = SoundID.NPCDeath2;
             NPC.knockBackResist = 0.5f;


### PR DESCRIPTION
includes some balancing for surface moon enemies, still sort of a prototype because it's my first time doing this so feedback appreciated
also included is a selenite magnum nerf and a nerf to luminite arrows which only affects selenite bow