### PR TITLE
moon enemy damage balance

### DIFF
--- a/Content/NPCs/Bosses/CraterDemon/CraterDemon.cs
+++ b/Content/NPCs/Bosses/CraterDemon/CraterDemon.cs
@@ -289,13 +289,13 @@ namespace Macrocosm.Content.NPCs.Bosses.CraterDemon
 
 			 /*PhantasmalPortalCount       */ { 0, 1, 1, 2, 1, 2, 2, 3 },
 
-             /*ChargeAttackCountMin        */ { 2, 3, 2, 4, 2, 4, 2, 4 },                       
+             /*ChargeAttackCountMin        */ { 1, 2, 2, 4, 2, 4, 2, 4 },                       
 			 /*ChargeAttackCountMax        */ { 3, 4, 3, 5, 3, 5, 3, 5 },
 			 /*ChargeWaitTime              */ { 60, 20, 50, 15, 45, 10, 45, 10 },    
 			 /*ChargeSlowdownDelay         */ { 30, 16, 26, 14, 45, 22, 12, 18 },    
 			 
 			 /*PortalWaitTimeMin           */ { 80, 70, 40, 30, 20, 10, 5, 0 },                   
-			 /*PortalWaitTimeMax           */ { 160, 150, 80, 70, 40, 30, 10, 5 },                
+			 /*PortalWaitTimeMax           */ { 160, 140, 80, 70, 40, 30, 10, 5 },                
 			 /*PortalIdleTime              */ { 60, 55, 35, 30, 25, 20, 15, 10 },                 
 			 /*PortalChargeAttackCountMin  */ { 1, 2, 1, 2, 1, 2, 1, 2 },                       
 			 /*PortalChargeAttackCountMax  */ { 2, 3, 2, 3, 2, 3, 2, 3 },
@@ -427,7 +427,7 @@ namespace Macrocosm.Content.NPCs.Bosses.CraterDemon
             NPC.knockBackResist = 0f;
 
             NPC.defense = 150;
-            NPC.damage = 80;
+            NPC.damage = 50;
             NPC.lifeMax = 80000;
 
             NPC.boss = true;

--- a/Content/NPCs/Enemies/Moon/Clavite.cs
+++ b/Content/NPCs/Enemies/Moon/Clavite.cs
@@ -45,7 +45,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
             NPC.width = 56;
             NPC.height = 56;
             NPC.lifeMax = 1100;
-            NPC.damage = 85;
+            NPC.damage = 55;
             NPC.defense = 110;
             NPC.HitSound = SoundID.NPCHit2;
             NPC.DeathSound = SoundID.NPCDeath2;

--- a/Content/NPCs/Enemies/Moon/CraterCrawler.cs
+++ b/Content/NPCs/Enemies/Moon/CraterCrawler.cs
@@ -38,7 +38,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.CloneDefaults(NPCID.DiggerHead);
             NPC.lifeMax = 1600;
-            NPC.damage = 90;
+            NPC.damage = 70;
             NPC.defense = 100;
             NPC.width = 20;
             NPC.height = 20;

--- a/Content/NPCs/Enemies/Moon/CrescentGhoul.cs
+++ b/Content/NPCs/Enemies/Moon/CrescentGhoul.cs
@@ -50,7 +50,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
             NPC.width = 72;
             NPC.height = 84;
             NPC.lifeMax = 1300;
-            NPC.damage = 65;
+            NPC.damage = 60;
             NPC.defense = 100;
             NPC.HitSound = SoundID.NPCHit2;
             NPC.DeathSound = SoundID.NPCDeath2;

--- a/Content/NPCs/Enemies/Moon/Dweller/Dweller.cs
+++ b/Content/NPCs/Enemies/Moon/Dweller/Dweller.cs
@@ -348,7 +348,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon.Dweller
 
         public override void SetDefaults()
         {
-            NPC.damage = 150;
+            NPC.damage = 105;
             NPC.defense = 25;
             NPC.lifeMax = 20000;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/Hermites/Hermite.cs
+++ b/Content/NPCs/Enemies/Moon/Hermites/Hermite.cs
@@ -26,7 +26,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon.Hermites
         {
             NPC.width = 21;
             NPC.height = 32;
-            NPC.damage = 60;
+            NPC.damage = 65;
             NPC.defense = 100;
             NPC.lifeMax = 1300;
             NPC.HitSound = SoundID.NPCHit2;

--- a/Content/NPCs/Enemies/Moon/Leaper.cs
+++ b/Content/NPCs/Enemies/Moon/Leaper.cs
@@ -29,7 +29,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
 
             NPC.width = 36;
             NPC.height = 44;
-            NPC.damage = 65;
+            NPC.damage = 60;
             NPC.defense = 70;
             NPC.lifeMax = 900;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/LuminiteElemental.cs
+++ b/Content/NPCs/Enemies/Moon/LuminiteElemental.cs
@@ -70,7 +70,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 38;
             NPC.height = 38;
-            NPC.damage = 75;
+            NPC.damage = 60;
             NPC.defense = 100;
             NPC.lifeMax = 1300;
             NPC.HitSound = SoundID.Dig;

--- a/Content/NPCs/Enemies/Moon/LuminiteSlime.cs
+++ b/Content/NPCs/Enemies/Moon/LuminiteSlime.cs
@@ -27,7 +27,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 36;
             NPC.height = 22;
-            NPC.damage = 80;
+            NPC.damage = 60;
             NPC.defense = 80;
             NPC.lifeMax = 700;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/LuminiteSlimeVolatile.cs
+++ b/Content/NPCs/Enemies/Moon/LuminiteSlimeVolatile.cs
@@ -12,7 +12,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             base.SetDefaults();
             NPC.lifeMax = 650;
-            NPC.damage = 80;
+            NPC.damage = 70;
             NPC.defense = 70;
         }
 

--- a/Content/NPCs/Enemies/Moon/MoonLich/LunarChimera.cs
+++ b/Content/NPCs/Enemies/Moon/MoonLich/LunarChimera.cs
@@ -33,7 +33,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon.MoonLich
         {
             NPC.width = 52;
             NPC.height = 50;
-            NPC.damage = 100;
+            NPC.damage = 80;
             NPC.defense = 100;
             NPC.lifeMax = 1500;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/MoonLich/MoonLich.cs
+++ b/Content/NPCs/Enemies/Moon/MoonLich/MoonLich.cs
@@ -40,7 +40,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon.MoonLich
             NPC.width = 46;
             NPC.height = 46;
             NPC.lifeMax = 15000;
-            NPC.damage = 60;
+            NPC.damage = 70;
             NPC.defense = 90;
             NPC.HitSound = SoundID.NPCHit2;
             NPC.DeathSound = SoundID.NPCDeath2;

--- a/Content/NPCs/Enemies/Moon/MoonLich/XenoHornet.cs
+++ b/Content/NPCs/Enemies/Moon/MoonLich/XenoHornet.cs
@@ -23,7 +23,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon.MoonLich
 
             NPC.width = 34;
             NPC.height = 34;
-            NPC.damage = 80;
+            NPC.damage = 65;
             NPC.defense = 50;
             NPC.lifeMax = 200;
 

--- a/Content/NPCs/Enemies/Moon/MoonWorm.cs
+++ b/Content/NPCs/Enemies/Moon/MoonWorm.cs
@@ -87,7 +87,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         public override void SetDefaults()
         {
             NPC.CloneDefaults(NPCID.DiggerHead);
-            NPC.damage = 175;
+            NPC.damage = 110;
             NPC.lifeMax = 8000;
             NPC.defense = 160;
             FlipSprite = true;

--- a/Content/NPCs/Enemies/Moon/MoonZombie.cs
+++ b/Content/NPCs/Enemies/Moon/MoonZombie.cs
@@ -21,7 +21,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 18;
             NPC.height = 44;
-            NPC.damage = 80;
+            NPC.damage = 70;
             NPC.defense = 90;
             NPC.lifeMax = 1000;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/RadioactiveSlime.cs
+++ b/Content/NPCs/Enemies/Moon/RadioactiveSlime.cs
@@ -30,7 +30,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
 
             NPC.width = 36;
             NPC.height = 22;
-            NPC.damage = 50;
+            NPC.damage = 60;
             NPC.defense = 80;
             NPC.lifeMax = 2100;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/RegolithSlime.cs
+++ b/Content/NPCs/Enemies/Moon/RegolithSlime.cs
@@ -22,7 +22,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 36;
             NPC.height = 22;
-            NPC.damage = 60;
+            NPC.damage = 50;
             NPC.defense = 60;
             NPC.lifeMax = 900;
             NPC.HitSound = SoundID.NPCHit1;

--- a/Content/NPCs/Enemies/Moon/ZombieSecurity.cs
+++ b/Content/NPCs/Enemies/Moon/ZombieSecurity.cs
@@ -66,7 +66,7 @@ namespace Macrocosm.Content.NPCs.Enemies.Moon
         {
             NPC.width = 24;
             NPC.height = 44;
-            NPC.damage = 75;
+            NPC.damage = 70;
             NPC.defense = 100;
             NPC.lifeMax = 1300;
             NPC.HitSound = SoundID.NPCHit1;


### PR DESCRIPTION
mostly nerfs, tried to keep all enemies dealing about 50 damage per attack (some varying based on how much damage they'd reasonably dish out)
some enemies are balanced with astronaut gear in mind since you'll see them first (all day surface enemies, all 2 of them, and some ug moon enemies that arent moon lich (and summons) and dweller)
the rest are based on artemite gear
all of this done in normal mode, fairly confident with this, let me know of any egregious errors