### PR TITLE
Update Wikithis to use wiki.gg not fandom

### DIFF
--- a/Common/CrossMod/CrossMod.cs
+++ b/Common/CrossMod/CrossMod.cs
@@ -129,7 +129,7 @@ namespace Macrocosm.Common.Crossmod
         {
             if (ModLoader.TryGetMod("Wikithis", out Mod wikithis) && !Main.dedServ)
             {
-                wikithis.Call("AddModURL", Mod, "https://terrariamods.fandom.com/wiki/Macrocosm/{}");
+                wikithis.Call("AddModURL", Mod, "https://terrariamods.wiki.gg/wiki/Macrocosm/{}");
             }
         }
     }


### PR DESCRIPTION
Updated the Wikithis link to point at the wiki.gg url instead of fandom.