### PR TITLE
More localization shenanigans

### DIFF
--- a/Common/Systems/Power/ConsumerTE.cs
+++ b/Common/Systems/Power/ConsumerTE.cs
@@ -1,4 +1,4 @@
-﻿using Macrocosm.Common.Utils;
+using Macrocosm.Common.Utils;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using System;
@@ -44,7 +44,7 @@ public abstract class ConsumerTE : MachineTE
 
     public override void DrawMachinePowerInfo(SpriteBatch spriteBatch, Vector2 basePosition, Color lightColor)
     {
-        string power = $"{InputPower:F2} / {PowerDemand:F2}kW";
+        string power = Language.GetText("Mods.Macrocosm.Machines.Common.PowerInfo.Common").Format($"{InputPower:F2}", $"{PowerDemand:F2}");
 
         Vector2 textSize = FontAssets.MouseText.Value.MeasureString(power);
         Vector2 position = new Vector2(basePosition.X + (MachineTile.Width * 16f / 2f) - (textSize.X / 2f) + 8f, basePosition.Y - 22f) - Main.screenPosition;

--- a/Common/UI/Machines/KeroseneGeneratorUI.cs
+++ b/Common/UI/Machines/KeroseneGeneratorUI.cs
@@ -209,7 +209,7 @@ public class KeroseneGeneratorUI : MachineUI
         inputArrowProgressBar.Progress = KeroseneGenerator.ConsumedItem.IsAir ? 0f : 1f - KeroseneGenerator.BurnProgress;
 
         float rpm = KeroseneGenerator.RPM;
-        rpmText.SetText($"{(int)rpm} RPM");
+        rpmText.SetText(Language.GetText("Mods.Macrocosm.Machines.KeroseneGenerator.RPM").Format((int)rpm));
 
         bool running = rpmProgress > 0.01f;
         if (running)

--- a/Localization/en-US/Mods.Macrocosm.Items.hjson
+++ b/Localization/en-US/Mods.Macrocosm.Items.hjson
@@ -3003,16 +3003,6 @@ PipeCutter: {
 	Tooltip: Removes conveyor pipes and attachments
 }
 
-CrudeWireRed: {
-	DisplayName: Crude Red Wrench
-	Tooltip: Places red wire
-}
-
-CrudeWireBlue: {
-	DisplayName: Crude Blue Wrench
-	Tooltip: Places blue wire
-}
-
 CrudeWireCutter: {
 	DisplayName: Crude Wire Cutter
 	Tooltip: Cuts wires
@@ -3659,13 +3649,13 @@ RegolithPlatform: {
 }
 
 CrudeWireWrenchBlue: {
-	DisplayName: Crude Wire Wrench Blue
-	Tooltip: ""
+	DisplayName: Crude Blue Wrench
+	Tooltip: Places blue wire
 }
 
 CrudeWireWrenchRed: {
-	DisplayName: Crude Wire Wrench Red
-	Tooltip: ""
+	DisplayName: Crude Red Wrench
+	Tooltip: Places red wire
 }
 
 HeveaBathtub: {

--- a/Localization/en-US/Mods.Macrocosm.Machines.hjson
+++ b/Localization/en-US/Mods.Macrocosm.Machines.hjson
@@ -1,5 +1,7 @@
 OilRefinery.DisplayName: Oil Refinery
+OreDrill.DisplayName: Ore Excavator
 OreExcavator.DisplayName: Ore Excavator
+Pumpjack.DisplayName: Pumpjack
 SteamEngine.DisplayName: Steam Engine
 AutocrafterT1.DisplayName: Tier 1 Assembler
 AutocrafterT2.DisplayName: Tier 2 Assembler
@@ -33,7 +35,7 @@ Common: {
 	PowerInfo: {
 		Simple: "{0}kW"
 		Energy: "{0}kJ"
-		Common: "{0}kW / {1}kW"
+		Common: "{0} / {1}kW"
 		Consumer: Supplied: {0}kW / Demand: {1}kW / Max: {2}kW
 		ConsumerIdle: Idle / Max: {0}kW
 		Generator: Generated: {0}kW / Max: {1}kW


### PR DESCRIPTION
1. Power-consuming machines now use a localization key "Machines.Common.PowerInfo.Common" for displaying their power usage. The key was tweaked accordingly
2. Kerosene Generator now uses a localization "Machines.KeroseneGenerator.RPM" for displaying RPM. Not sure why it wasn't used from the beginning, but better late than never!
3. Crude Wrenches now use proper localization keys for their name and description. Previously there were two separate sets of localization keys, one unused and one used but auto-generated
4. Ditto of the previous pull request, except now it's for machines. I am sure there is more to come, but those will probably come with a translation PR