### PR TITLE
Shimmer fix and Keyboard shaders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -355,3 +355,4 @@ MigrationBackup/
 .ionide/
 
 
+.github/copilot-instructions.md

--- a/Common/Global/MacrocosmGlobalLiquid.cs
+++ b/Common/Global/MacrocosmGlobalLiquid.cs
@@ -32,11 +32,11 @@ public class MacrocosmGlobalLiquid : GlobalLiquid
                     tilesIgnoreWater.Add(type);
         }
 
-    foreach (int type in tilesIgnoreWater)
-        Main.tileSolid[type] = !ignoreSolids;
+        foreach (int type in tilesIgnoreWater)
+            Main.tileSolid[type] = !ignoreSolids;
 
-    orig(ignoreSolids);
-}
+        orig(ignoreSolids);
+    }
 
     public override bool UpdateLiquid(int i, int j, int type, Liquid liquid)
     {

--- a/Common/Systems/ShimmerSystem.cs
+++ b/Common/Systems/ShimmerSystem.cs
@@ -51,8 +51,7 @@ public class ShimmerSystem : ModSystem
                     return;
                 }
             }
-
-            orig(self);
         }
+        orig(self);
     }
 }

--- a/Content/Events/DemonSunEvent.cs
+++ b/Content/Events/DemonSunEvent.cs
@@ -21,7 +21,7 @@ public class DemonSunEvent : MacrocosmEvent
     public override void Update(MacrocosmEventContext context, MacrocosmEventState state)
     {
         DemonSunEventState demonSunState = (DemonSunEventState)state;
-        Main.bloodMoon = state.Active;
+        Main.bloodMoon = state.Active; //Prevents blood moons from happening altogether, even on the overworld, since the bloody tear and the natural event never activate the event's state.
 
         demonSunState.TargetVisualIntensity = state.Active && AppliesVisuals(context.CurrentSubworld) ? 1f : 0f;
 

--- a/Content/Events/DemonSunEvent.cs
+++ b/Content/Events/DemonSunEvent.cs
@@ -21,7 +21,7 @@ public class DemonSunEvent : MacrocosmEvent
     public override void Update(MacrocosmEventContext context, MacrocosmEventState state)
     {
         DemonSunEventState demonSunState = (DemonSunEventState)state;
-        Main.bloodMoon = state.Active; //Prevents blood moons from happening altogether, even on the overworld, since the bloody tear and the natural event never activate the event's state.
+        Main.bloodMoon = state.Active;
 
         demonSunState.TargetVisualIntensity = state.Active && AppliesVisuals(context.CurrentSubworld) ? 1f : 0f;
 

--- a/Content/RGB/MacrocosmShaderConditions.cs
+++ b/Content/RGB/MacrocosmShaderConditions.cs
@@ -1,0 +1,41 @@
+﻿using Macrocosm.Common.Subworlds;
+using Macrocosm.Common.Systems;
+using Macrocosm.Content.Subworlds;
+using ReLogic.Peripherals.RGB;
+using SubworldLibrary;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.ModLoader;
+
+namespace Macrocosm.Content.RGB;
+public class EarthOrbitShaderCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return SubworldSystem.IsActive<EarthOrbitSubworld>();
+    }
+}
+public class MoonOrbitShaderCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return SubworldSystem.IsActive<MoonOrbitSubworld>();
+    }
+}
+public class MoonShaderCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return SubworldSystem.IsActive<Moon>();
+    }
+}
+public class PollutionShaderCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return !SubworldSystem.AnyActive<Macrocosm>() && TileCounts.Instance.EnoughPollution;
+    }
+}

--- a/Content/RGB/MacrocosmShaderConditions.cs
+++ b/Content/RGB/MacrocosmShaderConditions.cs
@@ -1,5 +1,7 @@
-﻿using Macrocosm.Common.Subworlds;
+﻿using Macrocosm.Common.Events;
+using Macrocosm.Common.Subworlds;
 using Macrocosm.Common.Systems;
+using Macrocosm.Content.Events;
 using Macrocosm.Content.Subworlds;
 using ReLogic.Peripherals.RGB;
 using SubworldLibrary;
@@ -8,6 +10,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Terraria;
 using Terraria.ModLoader;
 
 namespace Macrocosm.Content.RGB;
@@ -29,7 +32,7 @@ public class MoonShaderCondition : ChromaCondition
 {
     public override bool IsActive()
     {
-        return SubworldSystem.IsActive<Moon>();
+        return SubworldSystem.IsActive<Moon>() && (Main.LocalPlayer.ZoneOverworldHeight || Main.LocalPlayer.ZoneSkyHeight || Main.LocalPlayer.ZoneDirtLayerHeight);
     }
 }
 public class PollutionShaderCondition : ChromaCondition
@@ -37,5 +40,19 @@ public class PollutionShaderCondition : ChromaCondition
     public override bool IsActive()
     {
         return !SubworldSystem.AnyActive<Macrocosm>() && TileCounts.Instance.EnoughPollution;
+    }
+}
+public class MeteorShowerShaderCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return MacrocosmEventSystem.IsActive<MeteorStormEvent>();
+    }
+}
+public class MoonUndergroundCondition : ChromaCondition
+{
+    public override bool IsActive()
+    {
+        return SubworldSystem.IsActive<Moon>() && (Main.LocalPlayer.ZoneUnderworldHeight || Main.LocalPlayer.ZoneRockLayerHeight);
     }
 }

--- a/Content/RGB/MeteorRainShader.cs
+++ b/Content/RGB/MeteorRainShader.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.Xna.Framework;
+using Newtonsoft.Json.Linq;
+using ReLogic.Peripherals.RGB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.GameContent.RGB;
+
+namespace Macrocosm.Content.RGB;
+public class MeteorRainShader(Color meteorColour) : ChromaShader
+{
+    private Color meteorColor = meteorColour;
+    public override bool IsTransparentAt(EffectDetailLevel quality)
+    {
+        return true;
+    }
+    public override void Process(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        Vector4 colour = meteorColor.ToVector4();
+        Vector4 fadeVector = new Vector4(0, 0, 0, 0.25f);
+        for (int i = 0; i < fragment.Count; i++)
+        {
+            Point gridPositionOfIndex = fragment.GetGridPositionOfIndex(i);
+            Vector2 canvasPositionOfIndex = fragment.GetCanvasPositionOfIndex(i);
+            float num = (NoiseHelper.GetStaticNoise(gridPositionOfIndex.X) * 10f + time) % 10f - canvasPositionOfIndex.Y;
+            Vector4 vector2 = fadeVector;
+            if (num > 0f)
+            {
+                float amount = Math.Max(0f, 1.2f - num);
+                if (num < 0.2f)
+                {
+                    amount = num * 5f;
+                }
+                vector2 = Vector4.Lerp(vector2, colour, amount);
+            }
+            fragment.SetColor(i, vector2);
+        }
+    }
+}

--- a/Content/RGB/MoonSubworldShader.cs
+++ b/Content/RGB/MoonSubworldShader.cs
@@ -17,7 +17,7 @@ public class MoonSubworldShader(Color main1, Color main2) : ChromaShader
     private float starVisibility;
     public override void Update(float elapsedTime)
     {
-        //normally, Main.colorOfTheSkies would be used here: however, it does have a problem where theres a small period where its more purple ish, which doesnt fit in a place like the moon, which has no atmosphere. so this acts like a 
+        //normally, Main.colorOfTheSkies would be used here: however, it does have a problem where theres a small period where its more purple ish, which doesnt fit in a place like the moon, which has no atmosphere. so this acts like a substitute
         if (Main.dayTime)
         {
             float num = (float)(Main.time / 54000.0);

--- a/Content/RGB/MoonSubworldShader.cs
+++ b/Content/RGB/MoonSubworldShader.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.Xna.Framework;
+using ReLogic.Peripherals.RGB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent.RGB;
+
+namespace Macrocosm.Content.RGB;
+public class MoonSubworldShader(Color main1, Color main2) : ChromaShader
+{
+    private Color MainColor1 = main1;
+    private Color MainColor2 = main2;
+    private float TimeMultiplier;
+    private float starVisibility;
+    public override void Update(float elapsedTime)
+    {
+        //normally, Main.colorOfTheSkies would be used here: however, it does have a problem where theres a small period where its more purple ish, which doesnt fit in a place like the moon, which has no atmosphere. so this acts like a 
+        if (Main.dayTime)
+        {
+            float num = (float)(Main.time / 54000.0);
+            if (num < 0.25f)
+            {
+                TimeMultiplier = num / 0.25f;
+                starVisibility = 1f - num / 0.25f;
+            }
+            else if (num > 0.75f)
+            {
+                TimeMultiplier = (1 - num) / 0.25f;
+                starVisibility = (num - 0.75f) / 0.25f;
+            }
+            else
+            {
+                TimeMultiplier = 1;
+            }
+        }
+        else
+        {
+            TimeMultiplier = 0;
+            starVisibility = 1f;
+        }
+    }
+    public override bool IsTransparentAt(EffectDetailLevel quality)
+    {
+        return false;
+    }
+    [RgbProcessor(EffectDetailLevel.Low)]
+    private void ProcessLowDetail(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        for (int i = 0; i < fragment.Count; i++)
+        {
+            Vector4 color = Color.Lerp(MainColor1, MainColor2, (float)Math.Sin(time * 0.5f + fragment.GetCanvasPositionOfIndex(i).X) * 0.5f + 0.5f).ToVector4();
+            fragment.SetColor(i, color);
+        }
+    }
+    [RgbProcessor(EffectDetailLevel.High)]
+    private void ProcessHighDetail(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        Vector4 mainColor1 = MainColor1.ToVector4() * TimeMultiplier;
+        Vector4 mainColor2 = MainColor2.ToVector4() * TimeMultiplier;
+        mainColor1.W = 255;
+        mainColor2.W = 255;
+        for (int i = 0; i < fragment.Count; i++)
+        {
+            Vector2 canvasPosition = fragment.GetCanvasPositionOfIndex(i);
+            Point gridPosition = fragment.GetGridPositionOfIndex(i);
+            float amount = (float)Math.Sin(canvasPosition.X * 1.5f + canvasPosition.Y + time) * 0.5f + 0.5f;
+            Vector4 value3 = Vector4.Lerp(mainColor1, mainColor2, amount);
+            float dynamicNoise = NoiseHelper.GetDynamicNoise(gridPosition.X, gridPosition.Y, time / 60f);
+            dynamicNoise = Math.Max(0f, 1f - dynamicNoise * 20f);
+            dynamicNoise *= 1f - TimeMultiplier;
+            value3 = Vector4.Max(value3, new Vector4(dynamicNoise * starVisibility));
+            fragment.SetColor(i, value3);
+        }
+    }
+}

--- a/Content/RGB/MoonSubworldShader.cs
+++ b/Content/RGB/MoonSubworldShader.cs
@@ -60,8 +60,8 @@ public class MoonSubworldShader(Color main1, Color main2) : ChromaShader
     {
         Vector4 mainColor1 = MainColor1.ToVector4() * TimeMultiplier;
         Vector4 mainColor2 = MainColor2.ToVector4() * TimeMultiplier;
-        mainColor1.W = 255;
-        mainColor2.W = 255;
+        mainColor1.W = 1;
+        mainColor2.W = 1;
         for (int i = 0; i < fragment.Count; i++)
         {
             Vector2 canvasPosition = fragment.GetCanvasPositionOfIndex(i);

--- a/Content/RGB/OrbitShader.cs
+++ b/Content/RGB/OrbitShader.cs
@@ -1,0 +1,79 @@
+﻿using Microsoft.Xna.Framework;
+using ReLogic.Peripherals.RGB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria;
+using Terraria.GameContent.RGB;
+
+namespace Macrocosm.Content.RGB;
+public class OrbitShader(Color main1, Color main2) : ChromaShader
+{
+    private Color MainColor1 = main1;
+    private Color MainColor2 = main2;
+    private float TimeMultiplier;
+    public override void Update(float elapsedTime)
+    {
+        //normally, Main.colorOfTheSkies would be used here: however, it does have a problem where theres a small period where its more purple ish, which doesnt fit in a place like the moon, which has no atmosphere. so this acts like a 
+        if (Main.dayTime)
+        {
+            float num = (float)(Main.time / 54000.0);
+            if (num < 0.25f)
+            {
+                TimeMultiplier = num / 0.25f;
+            }
+            else if (num > 0.75f)
+            {
+                TimeMultiplier = (1 - num) / 0.25f;
+            }
+            else
+            {
+                TimeMultiplier = 1;
+            }
+        }
+        else
+        {
+            TimeMultiplier = 0;
+        }
+    }
+
+    public override bool IsTransparentAt(EffectDetailLevel quality)
+    {
+        return false;
+    }
+    [RgbProcessor(EffectDetailLevel.Low)]
+    private void ProcessLowDetail(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        for (int i = 0; i < fragment.Count; i++)
+        {
+            Vector4 color = Color.Lerp(MainColor1, MainColor2, (float)Math.Sin(time * 0.5f + fragment.GetCanvasPositionOfIndex(i).X) * 0.5f + 0.5f).ToVector4();
+            fragment.SetColor(i, color);
+        }
+    }
+    [RgbProcessor(EffectDetailLevel.High)]
+    private void ProcessHighDetail(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        Vector4 timeVector = new Vector4(TimeMultiplier, TimeMultiplier, TimeMultiplier, 1);
+        Vector4 mainColor1 = MainColor1.ToVector4() * timeVector;
+        Vector4 mainColor2 = MainColor2.ToVector4() * timeVector;
+
+        for (int i = 0; i < fragment.Count; i++)
+        {
+            Vector2 canvasPosition = fragment.GetCanvasPositionOfIndex(i);
+            Point gridPosition = fragment.GetGridPositionOfIndex(i);
+            float amount = (float)Math.Sin(canvasPosition.X * 1.5f + canvasPosition.Y + time) * 0.5f + 0.5f;
+            Vector4 value3 = Vector4.Lerp(mainColor1, mainColor2, amount);
+            if (canvasPosition.Y < 0.66f)
+            {
+                value3 = Color.Black.ToVector4();
+                float dynamicNoise = NoiseHelper.GetDynamicNoise(gridPosition.X, gridPosition.Y, time / 60f);
+                dynamicNoise = Math.Max(0f, 1f - dynamicNoise * 20f);
+                value3 = Vector4.Max(value3, new Vector4(dynamicNoise));
+            }
+
+            fragment.SetColor(i, value3);
+        }
+    }
+}

--- a/Content/RGB/PollutionShader.cs
+++ b/Content/RGB/PollutionShader.cs
@@ -1,0 +1,44 @@
+﻿using Macrocosm.Common.Systems;
+using Microsoft.Xna.Framework;
+using ReLogic.Peripherals.RGB;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Terraria.GameContent.RGB;
+
+namespace Macrocosm.Content.RGB;
+public class PollutionShader(Color[] skyList, float panSpeedX, float panSpeedY) : ChromaShader
+{
+    private readonly Color[] skyList = skyList;
+    private readonly float timeScaleX = panSpeedX;
+    private readonly float timeScaleY = panSpeedY;
+    public override bool IsTransparentAt(EffectDetailLevel quality)
+    {
+        return true;
+    }
+    public override void Process(RgbDevice device, Fragment fragment, EffectDetailLevel quality, float time)
+    {
+        if (quality == EffectDetailLevel.Low) 
+        {
+            time *= 0.25f;
+        }
+        for (int i = 0; i < fragment.Count; i++) 
+        {
+            float scale = (TileCounts.Instance.PollutionLevel - TileCounts.PollutionLevelThreshold) / 100f;
+            
+            int colorIndex = (int)scale;
+            if (scale <= 0)
+            {
+                return;
+            }
+            Color fogColor = scale >= skyList.Length -1 ? skyList[^1] : skyList[colorIndex];
+            Color fogBackColor = skyList[colorIndex] * 0.40f;
+            float staticNoise = NoiseHelper.GetStaticNoise(fragment.GetCanvasPositionOfIndex(i) * new Vector2(0.2f, 0.4f) + new Vector2(time * this.timeScaleX, time * this.timeScaleY));
+            Vector4 color = Vector4.Lerp(fogBackColor.ToVector4(), fogColor.ToVector4(), staticNoise * staticNoise);
+            color.W *= (colorIndex * 0.15f + 0.3f);
+            fragment.SetColor(i, color);
+        }
+    }
+}

--- a/Localization/en-US/Mods.Macrocosm.NPCs.hjson
+++ b/Localization/en-US/Mods.Macrocosm.NPCs.hjson
@@ -74,6 +74,8 @@ MoonChampion: {
 		SolarStorm3: The Sun appears angry, human! Beware, sometimes frightening monsters ride the solar winds here, and they are not to be trifled with!
 		SolarStorm4: Do you taste metal, human?
 	}
+
+	Census.SpawnCondition: Conditions unknown
 }
 
 Clavite: {

--- a/Macrocosm.cs
+++ b/Macrocosm.cs
@@ -51,6 +51,8 @@ public class Macrocosm : Mod
         new(194, 45, 3),
         new(24, 0, 63)
     }, 0, 0.15f);
+    private static ChromaShader meteorSwarmShader = new MeteorRainShader(new Color(255, 90, 0f));
+    private static ChromaShader moonUGShader = new CavernShader(new Color(15, 15, 15), new Color(90, 90, 90), 0.5f);
 
     public override void Load()
     {
@@ -124,6 +126,8 @@ public class Macrocosm : Mod
         Main.Chroma.RegisterShader(moonOrbitShader, new MoonOrbitShaderCondition(), ShaderLayer.Biome);
         Main.Chroma.RegisterShader(moonShader, new MoonShaderCondition(), ShaderLayer.Biome);
         Main.Chroma.RegisterShader(pollutionShader, new PollutionShaderCondition(), ShaderLayer.BiomeModifier);
+        Main.Chroma.RegisterShader(meteorSwarmShader, new MeteorShowerShaderCondition(), ShaderLayer.Weather);
+        Main.Chroma.RegisterShader(moonUGShader, new MoonUndergroundCondition(), ShaderLayer.Biome);
     }
 
     private static void UnloadRGB()
@@ -132,6 +136,8 @@ public class Macrocosm : Mod
         Main.Chroma.UnregisterShader(moonOrbitShader);
         Main.Chroma.UnregisterShader(moonShader);
         Main.Chroma.UnregisterShader(pollutionShader);
+        Main.Chroma.UnregisterShader(meteorSwarmShader);
+        Main.Chroma.UnregisterShader(moonUGShader);
     }
     public override void HandlePacket(BinaryReader reader, int whoAmI)
     {

--- a/Macrocosm.cs
+++ b/Macrocosm.cs
@@ -1,11 +1,15 @@
 using Macrocosm.Common.Netcode;
 using Macrocosm.Common.Systems;
+using Macrocosm.Content.RGB;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using ReLogic.Content;
+using ReLogic.Peripherals.RGB;
 using System;
 using System.IO;
 using Terraria;
 using Terraria.GameContent;
+using Terraria.GameContent.RGB;
 using Terraria.GameContent.Shaders;
 using Terraria.Graphics.Effects;
 using Terraria.Graphics.Shaders;
@@ -36,6 +40,18 @@ public class Macrocosm : Mod
     public static Type[] GetTypes() => AssemblyManager.GetLoadableTypes(Instance.Code);
     public static Effect GetShader(string name) => GameShaders.Misc[$"{Instance.Name}:{name}"].Shader;
 
+    private static ChromaShader earthOrbitShader = new OrbitShader(new Color(116, 133, 35), new Color(30, 72, 159));
+    private static ChromaShader moonOrbitShader = new OrbitShader(new Color(177, 177, 177), new Color(33, 33, 33));
+    private static ChromaShader moonShader = new MoonSubworldShader(new Color(177, 177, 177), new Color(33, 33, 33));
+    private static ChromaShader pollutionShader = new PollutionShader(new Color[]
+    {
+        new(198, 239, 126),
+        new(211, 211, 82),
+        new(207, 166, 49),
+        new(194, 45, 3),
+        new(24, 0, 63)
+    }, 0, 0.15f);
+
     public override void Load()
     {
         CurrencySystem.Load();
@@ -45,6 +61,7 @@ public class Macrocosm : Mod
             EmptyTex = ModContent.Request<Texture2D>(EmptyTexPath);
             LoadResprites();
             LoadEffects();
+            LoadRGB();
         }
     }
 
@@ -52,6 +69,7 @@ public class Macrocosm : Mod
     {
         UnloadResprites();
         UnloadEffects();
+        UnloadRGB();
     }
 
     public override void PostSetupContent()
@@ -100,7 +118,21 @@ public class Macrocosm : Mod
     {
         // What goes here?
     }
+    private static void LoadRGB()
+    {
+        Main.Chroma.RegisterShader(earthOrbitShader, new EarthOrbitShaderCondition(), ShaderLayer.Biome);
+        Main.Chroma.RegisterShader(moonOrbitShader, new MoonOrbitShaderCondition(), ShaderLayer.Biome);
+        Main.Chroma.RegisterShader(moonShader, new MoonShaderCondition(), ShaderLayer.Biome);
+        Main.Chroma.RegisterShader(pollutionShader, new PollutionShaderCondition(), ShaderLayer.BiomeModifier);
+    }
 
+    private static void UnloadRGB()
+    {
+        Main.Chroma.UnregisterShader(earthOrbitShader);
+        Main.Chroma.UnregisterShader(moonOrbitShader);
+        Main.Chroma.UnregisterShader(moonShader);
+        Main.Chroma.UnregisterShader(pollutionShader);
+    }
     public override void HandlePacket(BinaryReader reader, int whoAmI)
     {
         PacketHandler.HandlePacket(reader, whoAmI);


### PR DESCRIPTION
Pretty self-explanatory
This pull request includes:

1. Keyboard shaders for all orbit subworlds, the surface and underground moon, the Pollution and the meteor swarm event.
2. A patch that fixes the bug that prevents shimmer from working for most items.